### PR TITLE
fix: repair CI/CD pipeline with correct action references and paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, development]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   release:
-    types: [ published ]
+    types: [published]
 
 env:
   MODULE_NAME: TerraformCloud
@@ -19,14 +19,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v1
-
       - name: Build module
         shell: pwsh
         run: |
           Write-Host "Building module..."
-          ./Build/build.ps1
+          ./Build-Module.ps1 -SkipTests
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -42,20 +39,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        psversion: ['5.1', '7.x']
+        psversion: ["5.1", "7.x"]
         exclude:
           - os: ubuntu-latest
-            psversion: '5.1'
+            psversion: "5.1"
           - os: macos-latest
-            psversion: '5.1'
+            psversion: "5.1"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup PowerShell ${{ matrix.psversion }}
-        uses: actions/setup-powershell@v1
-        if: matrix.psversion != '5.1'
 
       - name: Install Pester
         shell: pwsh
@@ -90,9 +83,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v1
 
       - name: Install PSScriptAnalyzer
         shell: pwsh
@@ -130,9 +120,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v1
-
       - name: Install Pester
         shell: pwsh
         run: |
@@ -164,9 +151,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v1
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the TerraformCloud PowerShell module will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Remove nonexistent `actions/setup-powershell@v1` from CI workflow; `pwsh` is pre-installed on all GitHub-hosted runners
+- Fix build script path in CI from `./Build/build.ps1` to `./Build-Module.ps1`
+- Fix push trigger branch name from `develop` to `development`
+
 ## [1.0.0] - 2025-10-17
 
 ### Added - Initial Release
@@ -360,20 +368,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Migration from Previous Scripts
 
-| Old Script | New Function |
-|------------|--------------|
-| `Get-TFCCurrentState.ps1` | `Get-TfcCurrentStateVersion` |
-| `Get-TFCEntitlementSet.ps1` | `Get-TfcOrganizationEntitlements` |
-| `Get-TFCTeamAccess.ps1` | `Get-TfcTeamAccess` |
-| `Get-TFCTeams.ps1` | `Get-TfcTeam` |
-| `Get-TFCUserFromToken.ps1` | `Get-TfcCurrentUser` |
-| `Get-TFCWorkspaces.ps1` | `Get-TfcWorkspace` |
-| `Get-TFCWorkspaceVariables.ps1` | `Get-TfcWorkspaceVariable` |
-| `Set-TFCWorkspaceVariable.ps1` | `Set-TfcWorkspaceVariable` |
-| `Update-TFCWorkspaceVariable.ps1` | `Update-TfcWorkspaceVariable` |
-| `Remove-TFCWorkspaceVariable.ps1` | `Remove-TfcWorkspaceVariable` |
-| `Find-TFCWorkspace.ps1` | `Find-TfcWorkspace` |
-| `Test-TFCWorkspaceId.ps1` | `Test-TfcWorkspaceId` |
+| Old Script                        | New Function                      |
+| --------------------------------- | --------------------------------- |
+| `Get-TFCCurrentState.ps1`         | `Get-TfcCurrentStateVersion`      |
+| `Get-TFCEntitlementSet.ps1`       | `Get-TfcOrganizationEntitlements` |
+| `Get-TFCTeamAccess.ps1`           | `Get-TfcTeamAccess`               |
+| `Get-TFCTeams.ps1`                | `Get-TfcTeam`                     |
+| `Get-TFCUserFromToken.ps1`        | `Get-TfcCurrentUser`              |
+| `Get-TFCWorkspaces.ps1`           | `Get-TfcWorkspace`                |
+| `Get-TFCWorkspaceVariables.ps1`   | `Get-TfcWorkspaceVariable`        |
+| `Set-TFCWorkspaceVariable.ps1`    | `Set-TfcWorkspaceVariable`        |
+| `Update-TFCWorkspaceVariable.ps1` | `Update-TfcWorkspaceVariable`     |
+| `Remove-TFCWorkspaceVariable.ps1` | `Remove-TfcWorkspaceVariable`     |
+| `Find-TFCWorkspace.ps1`           | `Find-TfcWorkspace`               |
+| `Test-TFCWorkspaceId.ps1`         | `Test-TfcWorkspaceId`             |
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove nonexistent `actions/setup-powershell@v1` from all CI jobs — `pwsh` is pre-installed on GitHub-hosted runners
- Fix build script path from `./Build/build.ps1` to `./Build-Module.ps1`
- Fix push trigger branch name from `develop` to `development`

Closes #1