### PR TITLE
feat: automate release assets and PSGallery link in CI pipeline

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,6 +96,11 @@ When a release is called for:
    > exact code that is in production. Tagging before the merge would point the
    > release at a `development` commit that may differ from `main` after merge.
 
+   The CI pipeline automatically handles everything after `gh release create`:
+   - Publishes the module to the PowerShell Gallery
+   - Creates and uploads compiled module archives (`.zip` and `.tar.gz`)
+   - Prepends a PowerShell Gallery install block and link to the release notes
+
 
 ## Module Architecture
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, test, analyze]
     if: github.event_name == 'release'
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
@@ -170,8 +172,36 @@ jobs:
 
           Publish-Module -Path ./Output/TerraformCloud -NuGetApiKey $env:NUGET_API_KEY -Verbose
 
-      - name: Create release notes
+      - name: Package compiled module
         shell: pwsh
         run: |
           $version = (Import-PowerShellDataFile ./Output/TerraformCloud/TerraformCloud.psd1).ModuleVersion
-          Write-Host "Published TerraformCloud module version $version to PowerShell Gallery"
+          Compress-Archive -Path ./Output/TerraformCloud/* -DestinationPath "./TerraformCloud-v${version}.zip"
+          tar -czf "./TerraformCloud-v${version}.tar.gz" -C Output TerraformCloud/
+          Write-Host "Created release archives for v${version}"
+
+      - name: Upload release assets and update notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $version = (Import-PowerShellDataFile ./Output/TerraformCloud/TerraformCloud.psd1).ModuleVersion
+          $tag = "v${version}"
+
+          # Upload compiled module archives
+          gh release upload $tag "./TerraformCloud-v${version}.zip" "./TerraformCloud-v${version}.tar.gz" --clobber
+
+          # Prepend PSGallery install block to existing release notes
+          $existing = gh release view $tag --json body --jq .body
+          $header = "**Install from PowerShell Gallery:**" + "`n" +
+                    '```powershell' + "`n" +
+                    "Install-Module -Name TerraformCloud -RequiredVersion $version" + "`n" +
+                    '```' + "`n" +
+                    "[View on PowerShell Gallery](https://www.powershellgallery.com/packages/TerraformCloud/$version)" + "`n`n---`n`n"
+          $updated = $header + $existing
+          $notesFile = New-TemporaryFile
+          Set-Content -Path $notesFile -Value $updated -NoNewline
+          gh release edit $tag --notes-file $notesFile
+          Remove-Item $notesFile
+
+          Write-Host "Published TerraformCloud v${version} to PowerShell Gallery with release assets"


### PR DESCRIPTION
## Summary

- Add pipeline steps to the publish job that automatically:
  - Package the compiled module as `.zip` and `.tar.gz` archives
  - Upload both archives to the GitHub release as downloadable assets
  - Prepend a PowerShell Gallery install command and link to the release notes
- Add `permissions: contents: write` to the publish job for release asset uploads
- Update dev workflow instructions to document automated post-release behavior

## Test plan

- [ ] CI pipeline passes (build, test matrix, code analysis)
- [ ] On next release: verify `.zip` and `.tar.gz` are attached to the GitHub release
- [ ] On next release: verify PSGallery install block appears at top of release notes