### PR TITLE
fix(ci): remove CodeQL job from weekly security scan

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -11,27 +11,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/ci.yml
 
-  # ── CodeQL Analysis ───────────────────────────────────
-  codeql:
-    name: CodeQL Analysis (PowerShell)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
-        with:
-          languages: powershell
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
-        with:
-          category: /language:powershell
-
   # ── Stale Dependabot PRs ──────────────────────────────
   stale-dependabot:
     name: Flag stale Dependabot PRs
@@ -57,7 +36,7 @@ jobs:
   notify-on-failure:
     name: Create issue on failure
     runs-on: ubuntu-latest
-    needs: [ci, codeql, stale-dependabot]
+    needs: [ci, stale-dependabot]
     if: failure() && github.event_name == 'schedule'
     permissions:
       issues: write


### PR DESCRIPTION
## Summary

- Removes the `codeql` job from `.github/workflows/weekly-security.yml`.
- Removes the dangling `codeql` reference from `notify-on-failure.needs`.

## Why

The weekly security scan has been failing for several runs (most recent: [run 26393242401](https://github.com/sethbacon/hcp-terraform-pwsh/actions/runs/26393242401/job/77687711748)) with:

\`\`\`
##[error]Did not recognize the following languages: powershell
\`\`\`

CodeQL does not support PowerShell as a target language — supported languages are C/C++, C#, Go, Java/Kotlin, JavaScript/TypeScript, Python, Ruby, and Swift. This isn't a configuration issue that can be fixed; the language simply isn't a CodeQL target.

## Coverage after removal

The weekly scan still provides:

- **CI** (called as a reusable workflow) — runs the full test matrix + PSScriptAnalyzer.
- **PSScriptAnalyzer** is the equivalent SAST tool for PowerShell. All security rules are enabled by default; only \`PSUseSingularNouns\` is excluded in \`.psscriptanalyzer.psd1\`.
- **Stale Dependabot PR flagging.**
- **Failure-issue creation** on scheduled runs.
- **GitHub native secret scanning + push protection** (enabled at the repository level).
- **Dependabot security updates** (enabled at the repository level).

There is no package manifest to scan for dependency vulnerabilities, and no IaC / container manifests, so additional SCA/IaC tooling would not add coverage.

## Test plan

- [x] YAML parses cleanly (IDE linter clean).
- [ ] PR checks pass.
- [ ] Manual trigger of \`Weekly Security Scan\` via \`workflow_dispatch\` succeeds after merge.