### PR TITLE
feat(ci): emit PSScriptAnalyzer SARIF and add Legitify scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,15 +79,13 @@ jobs:
     name: Code Analysis
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install PSScriptAnalyzer
-        shell: pwsh
-        run: |
-          Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force -SkipPublisherCheck
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -95,19 +93,36 @@ jobs:
           name: module-build
           path: Output/TerraformCloud/
 
-      - name: Run PSScriptAnalyzer
+      - name: Run PSScriptAnalyzer (SARIF)
+        uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f # v1.1
+        with:
+          path: ./Output/TerraformCloud/TerraformCloud.psm1
+          recurse: true
+          output: results.sarif
+          settings: ./.psscriptanalyzer.psd1
+
+      - name: Upload SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif
+          category: psscriptanalyzer
+
+      - name: Fail on PSScriptAnalyzer errors
         shell: pwsh
         run: |
-          $results = Invoke-ScriptAnalyzer -Path ./Output/TerraformCloud/TerraformCloud.psm1 -Recurse -ReportSummary -Settings ./.psscriptanalyzer.psd1
-
-          if ($results | Where-Object Severity -eq 'Error') {
-            Write-Error "PSScriptAnalyzer found errors!"
+          Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force -SkipPublisherCheck
+          $results = Invoke-ScriptAnalyzer -Path ./Output/TerraformCloud/TerraformCloud.psm1 -Recurse -Settings ./.psscriptanalyzer.psd1
+          $errors = $results | Where-Object Severity -eq 'Error'
+          if ($errors) {
+            $errors | Format-Table
+            Write-Error "PSScriptAnalyzer found $($errors.Count) error(s)"
             exit 1
           }
-
-          if ($results | Where-Object Severity -eq 'Warning') {
-            Write-Warning "PSScriptAnalyzer found warnings"
-            $results | Where-Object Severity -eq 'Warning' | Format-Table
+          $warnings = $results | Where-Object Severity -eq 'Warning'
+          if ($warnings) {
+            Write-Host "PSScriptAnalyzer found $($warnings.Count) warning(s):"
+            $warnings | Format-Table
           }
 
   integration-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,13 +93,31 @@ jobs:
           name: module-build
           path: Output/TerraformCloud/
 
-      - name: Run PSScriptAnalyzer (SARIF)
-        uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f # v1.1
-        with:
-          path: ./Output/TerraformCloud/TerraformCloud.psm1
-          recurse: true
-          output: results.sarif
-          settings: ./.psscriptanalyzer.psd1
+      # Inlined instead of using microsoft/psscriptanalyzer-action — that
+      # wrapper has had no commits since 2023-03 and an open community
+      # request to mark it stale. The wrapper just installs PSScriptAnalyzer
+      # + ConvertToSARIF and pipes them together, which we do here directly.
+      - name: Run PSScriptAnalyzer and emit SARIF
+        shell: pwsh
+        run: |
+          Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force -SkipPublisherCheck
+          Install-Module -Name ConvertToSARIF    -Scope CurrentUser -Force
+          Import-Module ConvertToSARIF
+          $results = Invoke-ScriptAnalyzer `
+            -Path ./Output/TerraformCloud/TerraformCloud.psm1 `
+            -Recurse `
+            -Settings ./.psscriptanalyzer.psd1
+          # Always emit SARIF (even when empty) so the upload step has a file
+          $results | ConvertTo-SARIF -FilePath results.sarif
+          $errors   = @($results | Where-Object Severity -eq 'Error')
+          $warnings = @($results | Where-Object Severity -eq 'Warning')
+          Write-Host "PSScriptAnalyzer: $($errors.Count) error(s), $($warnings.Count) warning(s)"
+          if ($warnings) { $warnings | Format-Table }
+          if ($errors)   {
+            $errors | Format-Table
+            Write-Error "PSScriptAnalyzer found $($errors.Count) error(s)"
+            exit 1
+          }
 
       - name: Upload SARIF to GitHub Security tab
         if: always()
@@ -107,23 +125,6 @@ jobs:
         with:
           sarif_file: results.sarif
           category: psscriptanalyzer
-
-      - name: Fail on PSScriptAnalyzer errors
-        shell: pwsh
-        run: |
-          Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force -SkipPublisherCheck
-          $results = Invoke-ScriptAnalyzer -Path ./Output/TerraformCloud/TerraformCloud.psm1 -Recurse -Settings ./.psscriptanalyzer.psd1
-          $errors = $results | Where-Object Severity -eq 'Error'
-          if ($errors) {
-            $errors | Format-Table
-            Write-Error "PSScriptAnalyzer found $($errors.Count) error(s)"
-            exit 1
-          }
-          $warnings = $results | Where-Object Severity -eq 'Warning'
-          if ($warnings) {
-            Write-Host "PSScriptAnalyzer found $($warnings.Count) warning(s):"
-            $warnings | Format-Table
-          }
 
   integration-test:
     name: Integration Tests

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -11,6 +11,32 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/ci.yml
 
+  # ── Legitify: GitHub misconfiguration scan ────────────
+  # Audits this repo's GitHub settings (workflow permissions, secret
+  # scanning posture, fork policies, etc.). The action uploads SARIF
+  # to the Security tab itself when upload_code_scanning is true
+  # (default), so no separate upload step is needed.
+  #
+  # NOTE: GITHUB_TOKEN cannot grant the `administration: read` scope,
+  # so policies that require it (branch protection details, repo
+  # admin settings) will be skipped. For full coverage, switch
+  # github_token to a PAT or GitHub App token with admin:read.
+  legitify:
+    name: Legitify (repo misconfig audit)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Run Legitify
+        uses: Legit-Labs/legitify@002049404ef93b207048323fe996eb2330327031 # v1.0.11
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          analyze_self_only: "true"
+          scorecard: "no"
+          upload_code_scanning: "true"
+
   # ── Stale Dependabot PRs ──────────────────────────────
   stale-dependabot:
     name: Flag stale Dependabot PRs
@@ -36,7 +62,7 @@ jobs:
   notify-on-failure:
     name: Create issue on failure
     runs-on: ubuntu-latest
-    needs: [ci, stale-dependabot]
+    needs: [ci, legitify, stale-dependabot]
     if: failure() && github.event_name == 'schedule'
     permissions:
       issues: write


### PR DESCRIPTION
> **Stacked on #11** — once that lands, GitHub will rebase this PR onto main automatically.

## Summary

- **`ci.yml`** — Replaces the inline PSScriptAnalyzer step in the `Code Analysis` job with an inline pwsh step that runs PSScriptAnalyzer, produces SARIF via the `ConvertToSARIF` module, and uploads via `github/codeql-action/upload-sarif`. Findings now appear in the Security tab with dismissal/comment workflow. The same step hard-fails the build on `Error`-severity rules.
- **`weekly-security.yml`** — Adds a `legitify` job that audits this repo's GitHub configuration (workflow permissions, secret scanning posture, fork policies, etc.) and uploads its own SARIF to the Security tab. `notify-on-failure` now also depends on `legitify` so a failure opens an issue.

## Why inline instead of `microsoft/psscriptanalyzer-action`?

Initial draft used the Microsoft action, but checking its status:

| Signal                | Value                                                                              |
| --------------------- | ---------------------------------------------------------------------------------- |
| Last commit on `main` | 2023-03-03 (3+ years ago)                                                          |
| Last merged PR        | 2023-03-03                                                                         |
| Last release          | v1.1, 2022-09-13                                                                   |
| Maintainer activity   | Last public comment from a Microsoft maintainer: 2024-07                           |
| Community sentiment   | Issue #19 (Jan 2026) "Please update versions" — no response; issue #12 commented 2026-05-14 calling it dead |

No formal deprecation notice, but it's functionally abandonware. The wrapper does three things: installs `PSScriptAnalyzer`, installs `ConvertToSARIF`, pipes them. We do those three things directly in a ~15-line pwsh step and drop the dependency.

`ConvertToSARIF` itself is older (2021) but stable — SARIF schema is frozen, 726K downloads, owned by Microsoft, no deprecation notice. It's a single-purpose utility that doesn't need ongoing maintenance to work.

## Pinned action SHAs (verified against GitHub API)

| Action                              | Version | Commit SHA                                                          |
| ----------------------------------- | ------- | ------------------------------------------------------------------- |
| `Legit-Labs/legitify`               | v1.0.11 | `002049404ef93b207048323fe996eb2330327031`                          |
| `github/codeql-action/upload-sarif` | v4.36.0 | `7211b7c8077ea37d8641b6271f6a365a22a5fbfa` (already in repo)        |

Each SHA resolved via `gh api /repos/.../commits/<tag>` and cross-checked against `git/refs/tags/<tag>` — both lightweight tags pointing directly to a commit.

## Known limitation

`GITHUB_TOKEN` cannot grant the `administration: read` scope, so a subset of Legitify's policies (branch protection details, repo admin settings) will be skipped. The remaining policies still provide useful drift coverage. For full Legitify coverage, swap `github_token` for a PAT or a GitHub App token with `admin:read`. The workflow has a comment explaining this.

## Test plan

- [ ] Required CI checks pass (Build Module, Code Analysis with SARIF upload, test matrix, Conventional PR Title, Dependency Review).
- [ ] After merge, manually trigger `Weekly Security Scan` via `workflow_dispatch` and confirm:
  - Legitify job succeeds and its SARIF appears in the Security tab under category `legitify-report`.
  - PSScriptAnalyzer findings appear under category `psscriptanalyzer`.
- [ ] Verify no duplicate alerts (each tool uses a distinct SARIF category).
