### PR TITLE
fix(security): declare OutputType and emit BOM to clear 25 scan alerts

### DIFF
--- a/Build-Module.ps1
+++ b/Build-Module.ps1
@@ -134,7 +134,14 @@ $moduleContent += @"
 
 # Write the compiled module file
 $compiledModuleFile = Join-Path $ModulePath 'TerraformCloud.psm1'
-$moduleContent | Out-File -FilePath $compiledModuleFile -Encoding UTF8 -Force
+# UTF-8 with BOM — PSScriptAnalyzer flags PSUseBOMForUnicodeEncodedFile
+# on non-ASCII content without a BOM, and PowerShell 5.1 requires the BOM
+# to detect UTF-8 correctly when loading the module.
+[System.IO.File]::WriteAllText(
+    $compiledModuleFile,
+    $moduleContent,
+    [System.Text.UTF8Encoding]::new($true)
+)
 Write-Host "  ✓ Compiled module: TerraformCloud.psm1" -ForegroundColor Green
 Write-Host "    Total functions: $($exportedFunctions.Count)" -ForegroundColor Gray
 

--- a/src/Public/Organizations/Remove-TfcOrganization.ps1
+++ b/src/Public/Organizations/Remove-TfcOrganization.ps1
@@ -12,6 +12,7 @@
 #>
 function Remove-TfcOrganization {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$Organization

--- a/src/Public/Organizations/Remove-TfcOrganizationMembership.ps1
+++ b/src/Public/Organizations/Remove-TfcOrganizationMembership.ps1
@@ -1,5 +1,6 @@
 function Remove-TfcOrganizationMembership {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact='High')]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$MembershipId

--- a/src/Public/Organizations/Remove-TfcOrganizationToken.ps1
+++ b/src/Public/Organizations/Remove-TfcOrganizationToken.ps1
@@ -12,6 +12,7 @@
 #>
 function Remove-TfcOrganizationToken {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$Organization

--- a/src/Public/Plans/Save-TfcPlanExport.ps1
+++ b/src/Public/Plans/Save-TfcPlanExport.ps1
@@ -14,6 +14,7 @@
 #>
 function Save-TfcPlanExport {
     [CmdletBinding()]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$PlanExportId,

--- a/src/Public/SSHKeys/Remove-TfcSSHKey.ps1
+++ b/src/Public/SSHKeys/Remove-TfcSSHKey.ps1
@@ -12,6 +12,7 @@
 #>
 function Remove-TfcSSHKey {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$SSHKeyId

--- a/src/Public/StateVersions/Get-TfcStateFile.ps1
+++ b/src/Public/StateVersions/Get-TfcStateFile.ps1
@@ -16,6 +16,7 @@
 #>
 function Get-TfcStateFile {
     [CmdletBinding()]
+    [OutputType([string])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$StateVersionId,

--- a/src/Public/Variables/Remove-TfcVariableSet.ps1
+++ b/src/Public/Variables/Remove-TfcVariableSet.ps1
@@ -12,6 +12,7 @@
 #>
 function Remove-TfcVariableSet {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$VariableSetId

--- a/src/Public/Variables/Remove-TfcVariableSetProject.ps1
+++ b/src/Public/Variables/Remove-TfcVariableSetProject.ps1
@@ -14,6 +14,7 @@
 #>
 function Remove-TfcVariableSetProject {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$VariableSetId,

--- a/src/Public/Variables/Remove-TfcVariableSetStack.ps1
+++ b/src/Public/Variables/Remove-TfcVariableSetStack.ps1
@@ -14,6 +14,7 @@
 #>
 function Remove-TfcVariableSetStack {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$VariableSetId,

--- a/src/Public/Variables/Remove-TfcVariableSetVariable.ps1
+++ b/src/Public/Variables/Remove-TfcVariableSetVariable.ps1
@@ -1,5 +1,6 @@
 function Remove-TfcVariableSetVariable {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact='High')]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$VariableSetId,

--- a/src/Public/Variables/Remove-TfcVariableSetWorkspace.ps1
+++ b/src/Public/Variables/Remove-TfcVariableSetWorkspace.ps1
@@ -14,6 +14,7 @@
 #>
 function Remove-TfcVariableSetWorkspace {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$VariableSetId,

--- a/src/Public/Variables/Remove-TfcWorkspaceVariable.ps1
+++ b/src/Public/Variables/Remove-TfcWorkspaceVariable.ps1
@@ -14,6 +14,7 @@
 #>
 function Remove-TfcWorkspaceVariable {
     [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$WorkspaceId,

--- a/src/Public/Variables/Set-TfcVariableSetProject.ps1
+++ b/src/Public/Variables/Set-TfcVariableSetProject.ps1
@@ -14,6 +14,7 @@
 #>
 function Set-TfcVariableSetProject {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$VariableSetId,

--- a/src/Public/Variables/Set-TfcVariableSetStack.ps1
+++ b/src/Public/Variables/Set-TfcVariableSetStack.ps1
@@ -14,6 +14,7 @@
 #>
 function Set-TfcVariableSetStack {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$VariableSetId,

--- a/src/Public/Variables/Set-TfcVariableSetWorkspace.ps1
+++ b/src/Public/Variables/Set-TfcVariableSetWorkspace.ps1
@@ -14,6 +14,7 @@
 #>
 function Set-TfcVariableSetWorkspace {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$VariableSetId,


### PR DESCRIPTION
## Summary

Addresses all **25 open code scanning alerts** from the May 2026 weekly security scan.

| Rule | Count | Fix |
| --- | --- | --- |
| `PSUseOutputTypeCorrectly` | 24 | Added `[OutputType()]` attributes to 15 functions |
| `PSUseBOMForUnicodeEncodedFile` | 1 | Build-Module.ps1 now writes compiled `.psm1` with UTF-8 BOM |

## Per-finding fixes

### `[OutputType([bool])]` added to 14 functions

These functions all return `$true`/`$false` (success indicator) but never declared it:

- `Remove-TfcOrganization`
- `Remove-TfcOrganizationMembership`
- `Remove-TfcOrganizationToken`
- `Remove-TfcSSHKey`
- `Remove-TfcVariableSet`
- `Remove-TfcVariableSetProject`
- `Remove-TfcVariableSetStack`
- `Remove-TfcVariableSetVariable`
- `Remove-TfcVariableSetWorkspace`
- `Remove-TfcWorkspaceVariable`
- `Save-TfcPlanExport`
- `Set-TfcVariableSetProject`
- `Set-TfcVariableSetStack`
- `Set-TfcVariableSetWorkspace`

### `[OutputType([string])]` added to 1 function

- `Get-TfcStateFile` — returns either the state file content or the output path string.

### BOM encoding fix in `Build-Module.ps1`

`Out-File -Encoding UTF8` on PowerShell 7 writes UTF-8 **without** BOM (5.1 writes with BOM — inconsistent). Switched to:

```powershell
[System.IO.File]::WriteAllText(
    $compiledModuleFile,
    $moduleContent,
    [System.Text.UTF8Encoding]::new($true)
)
```

This is consistent across PS 5.1 / PS 7+ and emits the BOM, which PowerShell 5.1 also requires to correctly detect UTF-8 when loading the module — so this doubles as a robustness improvement for Windows PowerShell consumers.

## Verification

| Check | Before | After |
| --- | --- | --- |
| PSScriptAnalyzer findings | 25 | **0** |
| Unit tests passing | 937 / 937 | **937 / 937** |
| Compiled module starts with BOM bytes `EF BB BF` | No | **Yes** |

## Conventional commit type

`fix(security):` — release-please will roll this into the next patch bump (1.3.x).

## Test plan

- [x] Required CI checks pass.
- [ ] After merge, manually re-trigger the weekly security workflow and confirm the Code scanning alerts page reports 0 open findings.
