### PR TITLE
fix(ci): grant security-events: write to reusable CI workflow call

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -9,6 +9,13 @@ jobs:
   ci:
     name: CI
     secrets: inherit
+    # Permission ceiling for the reusable workflow. ci.yml's analyze job
+    # uploads SARIF to GitHub code scanning, which requires
+    # security-events: write. Reusable workflows cannot exceed the
+    # caller's per-job permissions, so we must grant it here.
+    permissions:
+      contents: read
+      security-events: write
     uses: ./.github/workflows/ci.yml
 
   # ── Legitify: GitHub misconfiguration scan ────────────


### PR DESCRIPTION
## Summary

Fixes the workflow validation error blocking \`Weekly Security Scan\`:

\`\`\`
Invalid workflow file: .github/workflows/weekly-security.yml#L9
The nested job 'analyze' is requesting 'security-events: write',
but is only allowed 'security-events: none'.
\`\`\`

## Root cause

PR #12 added SARIF upload to \`ci.yml\`'s \`analyze\` job, which requires \`security-events: write\`. That works fine when \`ci.yml\` is triggered directly by \`push\`/\`pull_request\` — per-job permissions take effect.

But \`weekly-security.yml\` calls \`ci.yml\` as a reusable workflow via \`uses:\`. For reusable workflows, the permission ceiling is set by the **calling job** in the parent workflow, not by the parent's defaults. The \`ci\` job in \`weekly-security.yml\` didn't declare any permissions, so the called workflow inherited \`security-events: none\` and validation failed.

## Fix

Add a \`permissions:\` block to the \`ci\` job in \`weekly-security.yml\` that grants what the called \`analyze\` job needs:

\`\`\`yaml
jobs:
  ci:
    name: CI
    secrets: inherit
    permissions:
      contents: read
      security-events: write
    uses: ./.github/workflows/ci.yml
\`\`\`

This is the minimum-scope fix — only the \`ci\` reusable-workflow job gets these permissions, not the entire weekly-security workflow. Legitify already has its own correct permissions block; stale-dependabot and notify-on-failure are unaffected.

## Test plan

- [ ] Required CI checks pass.
- [ ] After merge, manually trigger \`Weekly Security Scan\` via \`workflow_dispatch\` and confirm:
  - The \`ci\` job runs to completion (build + matrix tests + analyze with SARIF upload + integration-test).
  - PSScriptAnalyzer SARIF lands in the Security tab under category \`psscriptanalyzer\` showing 0 alerts (post #15).
  - Legitify and stale-dependabot jobs unaffected.