### PR TITLE
fix(ci): grant security-events: write to reusable CI call in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ jobs:
     name: CI
     needs: guard
     secrets: inherit
+    # Permission ceiling for the reusable workflow. ci.yml's analyze job
+    # uploads SARIF to GitHub code scanning, which requires
+    # security-events: write. Reusable workflows cannot exceed the
+    # caller's per-job permissions, so we must grant it here.
+    permissions:
+      contents: read
+      security-events: write
     uses: ./.github/workflows/ci.yml
 
   # ── Build module and attach to GitHub Release ──────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the same reusable-workflow permission ceiling issue from #17, but for \`release.yml\` instead of \`weekly-security.yml\`.

The v1.4.1 release tag (\`44b471c\`) failed to run with:

\`\`\`
The nested job 'analyze' is requesting 'security-events: write',
but is only allowed 'security-events: none'.
\`\`\`

## Fix

Adds the same \`permissions:\` block to the \`ci\` job in \`release.yml\`:

\`\`\`yaml
ci:
  name: CI
  needs: guard
  secrets: inherit
  permissions:
    contents: read
    security-events: write
  uses: ./.github/workflows/ci.yml
\`\`\`

## Why both fixes are needed

ci.yml is called from THREE places:

| Caller | Trigger | Status |
| --- | --- | --- |
| Direct trigger | push/PR to main | Works — per-job permissions apply directly |
| \`weekly-security.yml\` | schedule/dispatch | Fixed by #17 |
| \`release.yml\` | tag push | **Fixed by this PR** |

The other two reusable-workflow calls in \`release.yml\` (none — only \`ci\`) and \`weekly-security.yml\` (also only \`ci\`) are now covered.

## Release re-run

After this lands, the v1.4.1 release can be re-driven by:
1. Going to Actions → Release → most-recent run for v1.4.1
2. Clicking "Re-run all jobs"

Alternatively, deleting the v1.4.1 tag and re-pushing it via release-please will trigger a fresh run.

## Test plan

- [ ] Required CI checks pass.
- [ ] After merge, re-run the v1.4.1 release workflow and verify it progresses past the validation error.