### PR TITLE
ci: make Legitify step non-blocking in weekly security scan

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -37,6 +37,12 @@ jobs:
       actions: read
     steps:
       - name: Run Legitify
+        # Non-blocking: GITHUB_TOKEN cannot grant the scopes Legitify needs to
+        # self-audit this public repo, so it exits 1 with "insufficient
+        # permissions" on every scheduled run — and no tagged release carries a
+        # graceful skip. Let SARIF upload when it can, but don't fail the whole
+        # weekly run (and auto-file an issue) over this known token limitation.
+        continue-on-error: true
         # Pinned to the post-v1.0.11 main commit (PR #333) that replaces the
         # internal actions/upload-artifact@v3 — GitHub now hard-fails v3, which
         # broke every run since the deprecation (issues #20, #21). No tagged


### PR DESCRIPTION
## Problem

The weekly security scan (`.github/workflows/weekly-security.yml`) fails every Monday: the **Run Legitify** step exits 1 with "insufficient permissions". `GITHUB_TOKEN` cannot grant the scopes Legitify needs to self-audit this public repo, and no tagged Legitify release carries a graceful skip. The failed scheduled run then auto-files a "Scheduled build failed" issue (latest: #25).

## Fix

Add `continue-on-error: true` to the **Run Legitify** step (`uses: Legit-Labs/legitify@...`), with an inline comment explaining why it is non-blocking. The step is kept as-is, so SARIF still uploads to the Security tab when it can — this only stops the known token limitation from failing the whole weekly run and spamming issues.

No other changes. YAML confirmed well-formed.